### PR TITLE
Add prefix display support

### DIFF
--- a/irrtree/cli.py
+++ b/irrtree/cli.py
@@ -32,12 +32,12 @@ import re
 import socket
 import sys
 from collections import OrderedDict as OD
-from Queue import Queue
+from six.moves.queue import Queue
 
 try:
     import asciitree
 except ImportError:
-    print "ERROR: install asciitree: pip install asciitree"
+    print("ERROR: install asciitree: pip install asciitree")
     sys.exit(1)
 
 
@@ -52,7 +52,7 @@ def connect(irr_host, irr_port):
 def send(connection, command):
     sock, sock_in, sock_out = connection
     if debug:
-        print "sending: %s" % command
+        print("sending: %s" % command)
     sock_out.write(command + '\r\n')
     sock_out.flush()
 
@@ -70,11 +70,11 @@ def query(connection, cmd, as_set, recurse=False, search=False):
         return set()
     elif answer[0] == "F":
         if debug:
-            print "Error: %s" % answer[1:]
-            print "Query was: %s" % query
+            print("Error: %s" % answer[1:])
+            print("Query was: %s" % query)
     elif answer[0] == "A":
         if debug:
-            print "Info: receiving %s bytes" % answer[1:]
+            print("Info: receiving %s bytes" % answer[1:])
         unfiltered = receive(connection).split()
         results = set()
         if cmd == "i":
@@ -85,28 +85,29 @@ def query(connection, cmd, as_set, recurse=False, search=False):
                     results.add(result.upper())  # found as-set
                 else:
                     if debug:
-                        print "Warning: not honoring mbrs-by-ref for object %s with '%s'" % (as_set, result)
+                        print("Warning: not honoring mbrs-by-ref for object %s with '%s'" % (as_set, result))
         else:
             results = unfiltered
 
         if not receive(connection) == "C":
-            print "Error: something went wrong with: %s" % query
+            print("Error: something went wrong with: %s" % query)
 
         return set(results)
 
+
 def usage():
-    print "IRRtool v%s" % irrtree.__version__
-    print "usage: irrtree [-h host] [-p port] [-l sources] [-d] [-4 | -6] [-s ASXX] <AS-SET>"
-    print "   -d,--debug          print debug information"
-    print "   -4,--ipv4           resolve IPv4 prefixes (default)"
-    print "   -6,--ipv6           resolve IPv6 prefixes"
-    print "   -l,--list=SOURCES   list of sources (e.g.: RIPE,NTTCOM,RADB)"
-    print "   -p,--port=PORT      port on which IRRd runs (default: 43)"
-    print "   -h,--host=HOST      hostname to connect to (default: rr.ntt.net)"
-    print "   -s,--search=AUTNUM  output only related to autnum (in ASXXX format)"
-    print ""
-    print "Written by Job Snijders <job@instituut.net>"
-    print "Source: https://github.com/job/irrtree"
+    print("IRRtool v%s" % irrtree.__version__)
+    print("usage: irrtree [-h host] [-p port] [-l sources] [-d] [-4 | -6] [-s ASXX] <AS-SET>")
+    print("   -d,--debug          print debug information")
+    print("   -4,--ipv4           resolve IPv4 prefixes (default)")
+    print("   -6,--ipv6           resolve IPv6 prefixes")
+    print("   -l,--list=SOURCES   list of sources (e.g.: RIPE,NTTCOM,RADB)")
+    print("   -p,--port=PORT      port on which IRRd runs (default: 43)")
+    print("   -h,--host=HOST      hostname to connect to (default: rr.ntt.net)")
+    print("   -s,--search=AUTNUM  output only related to autnum (in ASXXX format)")
+    print("")
+    print("Written by Job Snijders <job@instituut.net>")
+    print("Source: https://github.com/job/irrtree")
     sys.exit()
 
 
@@ -123,12 +124,13 @@ def process(irr_host, afi, db, as_set, search):
     import datetime
     now = datetime.datetime.now()
     now = now.strftime("%Y-%m-%d %H:%M")
-    print "IRRTree (%s) report for '%s' (IPv%i), using %s at %s" \
-        % (irrtree.__version__, as_set, afi, irr_host, now)
+    print("IRRTree (%s) report for '%s' (IPv%i), using %s at %s" % (
+        irrtree.__version__, as_set, afi, irr_host, now
+    ))
 
-    if search and "-" not in db.keys():
-        if not search in db.keys():
-            print "NOT_FOUND: %s not present in %s or any of its members" % (search, as_set)
+    if search and "-" not in list(db.keys()):
+        if not search in list(db.keys()):
+            print("NOT_FOUND: %s not present in %s or any of its members" % (search, as_set))
             sys.exit()
 
     def print_member(as_set, db, search):
@@ -170,7 +172,7 @@ def process(irr_host, afi, db, as_set, search):
     tree = OD()
     tree["%s" % print_member(as_set, db, search)] = resolve_tree(as_set, db)
     tr = asciitree.LeftAligned()
-    print tr(tree)
+    print(tr(tree))
 
 
 def main():
@@ -189,7 +191,7 @@ def main():
                                    ["host=", "debug", "port=", "ipv6", "ipv4",
                                     "search=", "list="])
     except getopt.GetoptError as err:
-        print str(err)
+        print(str(err))
         usage()
 
     for o, a in opts:
@@ -209,7 +211,7 @@ def main():
     if not len(args) == 1:
         usage()
     if not "-" in args[0]:
-        print "Error: %s does not appear to be an AS-SET" % args[0]
+        print("Error: %s does not appear to be an AS-SET" % args[0])
         usage()
     query_object = args[0].upper()
 
@@ -222,13 +224,12 @@ def main():
         send(connection, "!s%s" % sources_list)
         answer = receive(connection)
         if answer is not "C":
-            print "Error: %s" % answer
+            print("Error: %s" % answer)
             sys.exit(2)
 
     db = {}
 
-    widgets = ['Processed: ', progressbar.Counter(), ' objects (',
-            progressbar.Timer(), ')']
+    widgets = ['Processed: ', progressbar.Counter(), ' objects (', progressbar.Timer(), ')']
     pbar = progressbar.ProgressBar(widgets=widgets, maxval=2**32)
     if not debug:
         pbar.start()
@@ -237,7 +238,7 @@ def main():
     while not queue.empty():
         item = queue.get()
         if debug:
-            print "Info: expanding %s" % item
+            print("Info: expanding %s" % item)
         if not "-" in item:  # expand aut-nums
             if not search or search == item:
                 prefixes = query(connection, "g" if afi == 4 else "6", item, False, False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-asciitree==0.3
-progressbar2==3.30.2
+asciitree==0.3.3
+progressbar2==3.38.0
+six==1.11.0

--- a/setup.py
+++ b/setup.py
@@ -32,10 +32,13 @@ import os
 import sys
 
 if not sys.version_info[0] >= 2 and not sys.version_info[1] >= 7:
-    print "ERROR for irrtree: Sorry, only python 2.7 or higher are supported"
+    print("ERROR for irrtree: Sorry, only python 2.7 or higher are supported")
     sys.exit(1)
 
-from pip.req import parse_requirements
+try:
+    from pip._internal.req import parse_requirements
+except ImportError:
+    from pip.req import parse_requirements
 from setuptools import setup, find_packages
 from os.path import abspath, dirname, join
 


### PR DESCRIPTION
When using bgpq3 etc to generate prefix lists from as-sets it can be useful to dig through exactly where in the chain an unexpected prefix got included.

irrtree already pulls all the prefixes down to count them, so adding an option to display them appears to make sense.

-x (as in extra {info}) writes the prefixes into a sub-tree, causing a display similar to:
```
AS-GLOBAL (261 ASNs, 267 pfxs)
+-- AS-LAN (27 ASNs, 50 pfxs)
|   +-- AS-FINECOM (27 ASNs, 50 pfxs)
|       +-- AS-TELEZUG (6 ASNs, 5 pfxs)
|       |   +-- AS-SHINTERNET (2 ASNs, 3 pfxs)
|       |   |   +-- AS35518 (3 pfxs)
|       |   |   |   +-- 2a00:d80::/32
[...]
```

Depends on https://github.com/job/irrtree/pull/8