### PR TITLE
Fix bar output on recent versions of progressbar2

### DIFF
--- a/irrtree/cli.py
+++ b/irrtree/cli.py
@@ -228,7 +228,7 @@ def main():
     db = {}
 
     widgets = ['Processed: ', progressbar.Counter(), ' objects (', progressbar.Timer(), ')']
-    pbar = progressbar.ProgressBar(widgets=widgets, maxval=2**32)
+    pbar = progressbar.ProgressBar(widgets=widgets, max_value=progressbar.UnknownLength)
     if not debug:
         pbar.start()
     counter = 0
@@ -274,6 +274,7 @@ def main():
             if "-" in item:
                 db[item]['members'] = db[item]['members'] - to_delete
 
+    pbar.finish()
     process(server.irr_host, server.afi, db, query_object, server.search)
 
 


### PR DESCRIPTION
On recent versions of progressbar2, the final displayed count is set to the value passed in `maxval`/`max_value` and the progress bar must be cleaned:

```bash
% irrtree -6 AS202945:AS-ALTNET
Processed: 5 objects (Elapsed Time: 0:00:00)                                           IRRTree (1.4.0) report for 'AS202945:AS-ALTNET' (IPv6), using rr.ntt.net at 2023-01-23 21:41
AS202945:AS-ALTNET (3 ASNs, 18 pfxs)
 +-- AS202945:AS-DOWNSTREAMS (2 ASNs, 14 pfxs)
 |   +-- AS210960 (13 pfxs)
 |   +-- AS211672 (1 pfxs)
 +-- AS202945 (4 pfxs)
Processed: 4294967296 objects (Elapsed Time: 0:00:00)
```

Fixed output:

```bash
python3 ./irrtree/cli.py -6 AS202945:AS-ALTNET
Processed: 5 objects (Elapsed Time: 0:00:00)
IRRTree (1.4.0) report for 'AS202945:AS-ALTNET' (IPv6), using rr.ntt.net at 2023-01-23 21:56
AS202945:AS-ALTNET (3 ASNs, 18 pfxs)
 +-- AS202945:AS-DOWNSTREAMS (2 ASNs, 14 pfxs)
 |   +-- AS210960 (13 pfxs)
 |   +-- AS211672 (1 pfxs)
 +-- AS202945 (4 pfxs)
 ```