### PR TITLE
Setup: Add wheel as a requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,8 +68,8 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
     ],
-    install_requires=['asciitree==0.3.3', 'progressbar2'],
-    setup_requires=['asciitree==0.3.3', 'progressbar2'],
+    install_requires=['asciitree==0.3.3', 'progressbar2', 'wheel'],
+    setup_requires=['asciitree==0.3.3', 'progressbar2', 'wheel'],
     packages=find_packages(exclude=['tests', 'tests.*']),
     entry_points={'console_scripts': ['irrtree = irrtree.cli:main']},
 )


### PR DESCRIPTION
When wheel package is not installed an error message will be printed to stdout.

Part of the msg will contain this:

```
WARNING: The wheel package is not available.
WARNING: The wheel package is not available.
  error: subprocess-exited-with-error
```

Suggestion is to add wheel as a requirement in setup.py with the existing requirements.